### PR TITLE
chore: sync prod back into dev

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,9 +1,9 @@
 {
-  "packages/config": "0.4.1",
-  "packages/modes": "0.4.1",
-  "packages/handoff": "0.4.1",
-  "packages/subagents": "0.4.1",
-  "packages/session-search": "0.4.1",
-  "packages/painter": "0.4.1",
-  "packages/extension": "0.4.1"
+  "packages/config": "0.5.0",
+  "packages/modes": "0.5.0",
+  "packages/handoff": "0.5.0",
+  "packages/subagents": "0.5.0",
+  "packages/session-search": "0.5.0",
+  "packages/painter": "0.5.0",
+  "packages/extension": "0.5.0"
 }

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.5.0](https://github.com/pi-ohm/pi-ohm/compare/v0.4.1...v0.5.0) (2026-02-17)
+
+
+### Features
+
+* changesets/publishing ([b82da81](https://github.com/pi-ohm/pi-ohm/commit/b82da81f08f4060ad9cd729af47b15c4117e4ab1))
+* fmt ([cdee2ff](https://github.com/pi-ohm/pi-ohm/commit/cdee2ff73a520ad8cf1131b88b1daab2c3bb0adc))
+* mono ([5a2e2f7](https://github.com/pi-ohm/pi-ohm/commit/5a2e2f763e2a20151583e8b94809d980f71b1206))
+* rename packages ([b00bb7a](https://github.com/pi-ohm/pi-ohm/commit/b00bb7a9206ac72b401a2eb32723adda59b9b847))
+* yarnh ([ad821cc](https://github.com/pi-ohm/pi-ohm/commit/ad821cc342d0c168f2a028d695f93ce96152bbfc))
+
+
+### Bug Fixes
+
+* add repository metadata to publishable packages ([9e7bb43](https://github.com/pi-ohm/pi-ohm/commit/9e7bb435ccaa14fdd0e70326e9b000b7222e3c6b))
+* add repository metadata to publishable packages ([dc791ad](https://github.com/pi-ohm/pi-ohm/commit/dc791ade07e565fc297e398b367cd1cb4b13f2d8))
+
 ## [0.4.1](https://github.com/pi-ohm/pi-ohm/compare/config-v0.4.0...config-v0.4.1) (2026-02-17)
 
 

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-ohm/config",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/extension/CHANGELOG.md
+++ b/packages/extension/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## [0.5.0](https://github.com/pi-ohm/pi-ohm/compare/v0.4.1...v0.5.0) (2026-02-17)
+
+
+### Features
+
+* changesets/publishing ([b82da81](https://github.com/pi-ohm/pi-ohm/commit/b82da81f08f4060ad9cd729af47b15c4117e4ab1))
+* modes ([c355c94](https://github.com/pi-ohm/pi-ohm/commit/c355c94b358afe239ccc173d4a88886d5a6093ab))
+* pi-ohm/modes pkg ([b8989c4](https://github.com/pi-ohm/pi-ohm/commit/b8989c4bffdee2d6a996ef1368ccae6bee0763c7))
+* publishing ([a6a0d3b](https://github.com/pi-ohm/pi-ohm/commit/a6a0d3b01644f4638de9ec258a5c49c53cf49dc4))
+* rename packages ([b00bb7a](https://github.com/pi-ohm/pi-ohm/commit/b00bb7a9206ac72b401a2eb32723adda59b9b847))
+
+
+### Bug Fixes
+
+* add repository metadata to publishable packages ([9e7bb43](https://github.com/pi-ohm/pi-ohm/commit/9e7bb435ccaa14fdd0e70326e9b000b7222e3c6b))
+* add repository metadata to publishable packages ([dc791ad](https://github.com/pi-ohm/pi-ohm/commit/dc791ade07e565fc297e398b367cd1cb4b13f2d8))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @pi-ohm/config bumped to 0.5.0
+    * @pi-ohm/handoff bumped to 0.5.0
+    * @pi-ohm/modes bumped to 0.5.0
+    * @pi-ohm/painter bumped to 0.5.0
+    * @pi-ohm/session-search bumped to 0.5.0
+    * @pi-ohm/subagents bumped to 0.5.0
+
 ## [0.4.1](https://github.com/pi-ohm/pi-ohm/compare/extension-v0.4.0...extension-v0.4.1) (2026-02-17)
 
 

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-ohm",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "type": "module",
   "main": "src/extension.ts",
   "types": "src/extension.ts",

--- a/packages/handoff/CHANGELOG.md
+++ b/packages/handoff/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.5.0](https://github.com/pi-ohm/pi-ohm/compare/v0.4.1...v0.5.0) (2026-02-17)
+
+
+### Features
+
+* changesets/publishing ([b82da81](https://github.com/pi-ohm/pi-ohm/commit/b82da81f08f4060ad9cd729af47b15c4117e4ab1))
+* rename packages ([b00bb7a](https://github.com/pi-ohm/pi-ohm/commit/b00bb7a9206ac72b401a2eb32723adda59b9b847))
+
+
+### Bug Fixes
+
+* add repository metadata to publishable packages ([9e7bb43](https://github.com/pi-ohm/pi-ohm/commit/9e7bb435ccaa14fdd0e70326e9b000b7222e3c6b))
+* add repository metadata to publishable packages ([dc791ad](https://github.com/pi-ohm/pi-ohm/commit/dc791ade07e565fc297e398b367cd1cb4b13f2d8))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @pi-ohm/config bumped to 0.5.0
+
 ## [0.4.1](https://github.com/pi-ohm/pi-ohm/compare/handoff-v0.4.0...handoff-v0.4.1) (2026-02-17)
 
 

--- a/packages/handoff/package.json
+++ b/packages/handoff/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-ohm/handoff",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "type": "module",
   "main": "src/extension.ts",
   "types": "src/extension.ts",

--- a/packages/modes/CHANGELOG.md
+++ b/packages/modes/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.5.0](https://github.com/pi-ohm/pi-ohm/compare/v0.4.1...v0.5.0) (2026-02-17)
+
+
+### Features
+
+* modes ([c355c94](https://github.com/pi-ohm/pi-ohm/commit/c355c94b358afe239ccc173d4a88886d5a6093ab))
+* pi-ohm/modes pkg ([b8989c4](https://github.com/pi-ohm/pi-ohm/commit/b8989c4bffdee2d6a996ef1368ccae6bee0763c7))
+
+
+### Bug Fixes
+
+* add repository metadata to publishable packages ([9e7bb43](https://github.com/pi-ohm/pi-ohm/commit/9e7bb435ccaa14fdd0e70326e9b000b7222e3c6b))
+* add repository metadata to publishable packages ([dc791ad](https://github.com/pi-ohm/pi-ohm/commit/dc791ade07e565fc297e398b367cd1cb4b13f2d8))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @pi-ohm/config bumped to 0.5.0
+
 ## [0.4.1](https://github.com/pi-ohm/pi-ohm/compare/modes-v0.4.0...modes-v0.4.1) (2026-02-17)
 
 

--- a/packages/modes/package.json
+++ b/packages/modes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-ohm/modes",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "type": "module",
   "main": "src/extension.ts",
   "types": "src/extension.ts",

--- a/packages/painter/CHANGELOG.md
+++ b/packages/painter/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.5.0](https://github.com/pi-ohm/pi-ohm/compare/v0.4.1...v0.5.0) (2026-02-17)
+
+
+### Features
+
+* changesets/publishing ([b82da81](https://github.com/pi-ohm/pi-ohm/commit/b82da81f08f4060ad9cd729af47b15c4117e4ab1))
+* rename packages ([b00bb7a](https://github.com/pi-ohm/pi-ohm/commit/b00bb7a9206ac72b401a2eb32723adda59b9b847))
+
+
+### Bug Fixes
+
+* add repository metadata to publishable packages ([9e7bb43](https://github.com/pi-ohm/pi-ohm/commit/9e7bb435ccaa14fdd0e70326e9b000b7222e3c6b))
+* add repository metadata to publishable packages ([dc791ad](https://github.com/pi-ohm/pi-ohm/commit/dc791ade07e565fc297e398b367cd1cb4b13f2d8))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @pi-ohm/config bumped to 0.5.0
+
 ## [0.4.1](https://github.com/pi-ohm/pi-ohm/compare/painter-v0.4.0...painter-v0.4.1) (2026-02-17)
 
 

--- a/packages/painter/package.json
+++ b/packages/painter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-ohm/painter",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "type": "module",
   "main": "src/extension.ts",
   "types": "src/extension.ts",

--- a/packages/session-search/CHANGELOG.md
+++ b/packages/session-search/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.5.0](https://github.com/pi-ohm/pi-ohm/compare/v0.4.1...v0.5.0) (2026-02-17)
+
+
+### Features
+
+* changesets/publishing ([b82da81](https://github.com/pi-ohm/pi-ohm/commit/b82da81f08f4060ad9cd729af47b15c4117e4ab1))
+* rename packages ([b00bb7a](https://github.com/pi-ohm/pi-ohm/commit/b00bb7a9206ac72b401a2eb32723adda59b9b847))
+
+
+### Bug Fixes
+
+* add repository metadata to publishable packages ([9e7bb43](https://github.com/pi-ohm/pi-ohm/commit/9e7bb435ccaa14fdd0e70326e9b000b7222e3c6b))
+* add repository metadata to publishable packages ([dc791ad](https://github.com/pi-ohm/pi-ohm/commit/dc791ade07e565fc297e398b367cd1cb4b13f2d8))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @pi-ohm/config bumped to 0.5.0
+
 ## [0.4.1](https://github.com/pi-ohm/pi-ohm/compare/session-search-v0.4.0...session-search-v0.4.1) (2026-02-17)
 
 

--- a/packages/session-search/package.json
+++ b/packages/session-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-ohm/session-search",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "type": "module",
   "main": "src/extension.ts",
   "types": "src/extension.ts",

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.5.0](https://github.com/pi-ohm/pi-ohm/compare/v0.4.1...v0.5.0) (2026-02-17)
+
+
+### Features
+
+* changesets/publishing ([b82da81](https://github.com/pi-ohm/pi-ohm/commit/b82da81f08f4060ad9cd729af47b15c4117e4ab1))
+* nice ([32a797c](https://github.com/pi-ohm/pi-ohm/commit/32a797c225b099d6b375a6d8ec9c70a2c16b2cee))
+
+
+### Bug Fixes
+
+* add repository metadata to publishable packages ([9e7bb43](https://github.com/pi-ohm/pi-ohm/commit/9e7bb435ccaa14fdd0e70326e9b000b7222e3c6b))
+* add repository metadata to publishable packages ([dc791ad](https://github.com/pi-ohm/pi-ohm/commit/dc791ade07e565fc297e398b367cd1cb4b13f2d8))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @pi-ohm/config bumped to 0.5.0
+
 ## [0.4.1](https://github.com/pi-ohm/pi-ohm/compare/subagents-v0.4.0...subagents-v0.4.1) (2026-02-17)
 
 

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-ohm/subagents",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "type": "module",
   "main": "src/extension.ts",
   "types": "src/extension.ts",


### PR DESCRIPTION
Automated sync PR to keep `dev` aligned with commits landed on `prod`
(release commits, manifest bumps, changelogs, and workflow updates).

This reduces dev/prod version drift.